### PR TITLE
feat: support different names for nft pallet

### DIFF
--- a/packages/page-nfts/src/AccountItems/useAccountItems.ts
+++ b/packages/page-nfts/src/AccountItems/useAccountItems.ts
@@ -1,6 +1,7 @@
 // Copyright 2017-2023 @polkadot/app-nfts authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { AugmentedQueries } from '@polkadot/api-base/types';
 import type { StorageKey, u32 } from '@polkadot/types';
 import type { AccountId32 } from '@polkadot/types/interfaces';
 import type { AccountItem } from '../types.js';
@@ -26,22 +27,24 @@ function transformResults (results: StorageKey<[AccountId32, u32, u32]>[][]): Ac
 
 function useAccountItemsImpl (): AccountItem[] | undefined {
   const mountedRef = useIsMountedRef();
-  const { api } = useApi();
+  const { api, apiDefaultNft } = useApi();
   const { allAccounts } = useAccounts();
 
   const [state, setState] = useState<AccountItem[] | undefined>();
+
+  const queryNftAccount = api.query[apiDefaultNft].account as AugmentedQueries<'promise'>['uniques']['account'];
 
   useEffect((): void => {
     if (!allAccounts.length) {
       return;
     }
 
-    const promises = allAccounts.map((account) => api.query.uniques.account.keys(account));
+    const promises = allAccounts.map((account) => queryNftAccount.keys(account));
 
     Promise.all(promises)
       .then((results) => mountedRef.current && setState(transformResults(results)))
       .catch(console.error);
-  }, [allAccounts, api.query.uniques.account, mountedRef]);
+  }, [allAccounts, queryNftAccount, mountedRef]);
 
   return state;
 }

--- a/packages/page-nfts/src/AccountItems/useItemsInfos.ts
+++ b/packages/page-nfts/src/AccountItems/useItemsInfos.ts
@@ -1,6 +1,7 @@
 // Copyright 2017-2023 @polkadot/app-nfts authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { AugmentedQueries } from '@polkadot/api-base/types';
 import type { Option } from '@polkadot/types';
 import type { PalletUniquesItemMetadata } from '@polkadot/types/lookup';
 import type { BN } from '@polkadot/util';
@@ -58,7 +59,7 @@ const addIpfsData = (ipfsData: IpfsData) => (itemInfo: ItemInfo): ItemInfo => {
 };
 
 function useItemsInfosImpl (accountItems: AccountItem[]): ItemInfo[] | undefined {
-  const { api } = useApi();
+  const { api, apiDefaultNft } = useApi();
   const [state, setState] = useState<ItemInfo[] | undefined>();
 
   const ids = useMemo(
@@ -66,7 +67,8 @@ function useItemsInfosImpl (accountItems: AccountItem[]): ItemInfo[] | undefined
     [accountItems]
   );
 
-  const metadata = useCall<[[[BN, BN][]], Option<PalletUniquesItemMetadata>[]]>(api.query.uniques.instanceMetadataOf.multi, [ids], QUERY_OPTS);
+  const queryNfts = api.query[apiDefaultNft] as AugmentedQueries<'promise'>['uniques'];
+  const metadata = useCall<[[[BN, BN][]], Option<PalletUniquesItemMetadata>[]]>(queryNfts.instanceMetadataOf.multi, [ids], QUERY_OPTS);
 
   const ipfsHashes = useMemo((): string[] | undefined => {
     if (metadata && metadata[1].length) {

--- a/packages/page-nfts/src/useCollectionIds.ts
+++ b/packages/page-nfts/src/useCollectionIds.ts
@@ -1,6 +1,7 @@
 // Copyright 2017-2023 @polkadot/app-nfts authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { AugmentedEvents, AugmentedQueries } from '@polkadot/api-base/types';
 import type { Changes } from '@polkadot/react-hooks/useEventChanges';
 import type { StorageKey, u32 } from '@polkadot/types';
 import type { EventRecord } from '@polkadot/types/interfaces';
@@ -30,13 +31,16 @@ function filter (records: EventRecord[]): Changes<u32> {
 }
 
 function useCollectionIdsImpl (): u32[] | undefined {
-  const { api } = useApi();
-  const startValue = useMapKeys(api.query.uniques.class, [], OPT_KEYS);
+  const { api, apiDefaultNft } = useApi();
+  const queryNfts = api.query[apiDefaultNft] as AugmentedQueries<'promise'>['uniques'];
+  const nftEvents = api.events[apiDefaultNft] as AugmentedEvents<'promise'>['uniques'];
+
+  const startValue = useMapKeys(queryNfts.class, [], OPT_KEYS);
 
   return useEventChanges([
-    api.events.uniques.Created,
-    api.events.uniques.Destroyed,
-    api.events.uniques.ForceCreated
+    nftEvents.Created,
+    nftEvents.Destroyed,
+    nftEvents.ForceCreated
   ], filter, startValue);
 }
 

--- a/packages/page-nfts/src/useCollectionInfos.ts
+++ b/packages/page-nfts/src/useCollectionInfos.ts
@@ -1,6 +1,7 @@
 // Copyright 2017-2023 @polkadot/app-nfts authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { AugmentedQueries } from '@polkadot/api-base/types';
 import type { Option } from '@polkadot/types';
 import type { AccountId } from '@polkadot/types/interfaces';
 import type { PalletUniquesCollectionDetails, PalletUniquesCollectionMetadata } from '@polkadot/types/lookup';
@@ -80,10 +81,11 @@ const addIpfsData = (ipfsData: IpfsData) => (collectionInfo: CollectionInfo): Co
 };
 
 function useCollectionInfosImpl (ids?: BN[]): CollectionInfo[] | undefined {
-  const { api } = useApi();
+  const { api, apiDefaultNft } = useApi();
+  const queryNfts = api.query[apiDefaultNft] as AugmentedQueries<'promise'>['uniques'];
   const { allAccounts } = useAccounts();
-  const metadata = useCall<[[BN[]], Option<PalletUniquesCollectionMetadata>[]]>(api.query.uniques.classMetadataOf.multi, [ids], QUERY_OPTS);
-  const details = useCall<[[BN[]], Option<PalletUniquesCollectionDetails>[]]>(api.query.uniques.class.multi, [ids], QUERY_OPTS);
+  const metadata = useCall<[[BN[]], Option<PalletUniquesCollectionMetadata>[]]>(queryNfts.classMetadataOf.multi, [ids], QUERY_OPTS);
+  const details = useCall<[[BN[]], Option<PalletUniquesCollectionDetails>[]]>(queryNfts.class.multi, [ids], QUERY_OPTS);
   const [state, setState] = useState<CollectionInfo[] | undefined>();
 
   const ipfsHashes = useMemo(

--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -142,7 +142,8 @@ async function loadOnReady (api: ApiPromise, endpoint: LinkOption | null, inject
     : settings.prefix;
   const tokenSymbol = properties.tokenSymbol.unwrapOr([formatBalance.getDefaults().unit, ...DEFAULT_AUX]);
   const tokenDecimals = properties.tokenDecimals.unwrapOr([DEFAULT_DECIMALS]);
-  const isEthereum = ethereumChains.includes(api.runtimeVersion.specName.toString());
+  const specName = api.runtimeVersion.specName.toString();
+  const isEthereum = ethereumChains.includes(specName);
   const isDevelopment = (systemChainType.isDevelopment || systemChainType.isLocal || isTestChain(systemChain));
 
   console.log(`chain: ${systemChain} (${systemChainType.toString()}), ${stringify(properties)}`);
@@ -180,9 +181,13 @@ async function loadOnReady (api: ApiPromise, endpoint: LinkOption | null, inject
   const apiDefaultTx = api.tx[defaultSection][defaultMethod];
   const apiDefaultTxSudo = (api.tx.system && api.tx.system.setCode) || apiDefaultTx;
 
+  const nodleMovesUniquesVersion = 23;
+  const apiDefaultNft = (specName === 'nodle-para') && (api.runtimeVersion.specVersion.toNumber() >= nodleMovesUniquesVersion) ? 'substrateUniques' : 'uniques';
+
   setDeriveCache(api.genesisHash.toHex(), deriveMapCache);
 
   return {
+    apiDefaultNft,
     apiDefaultTx,
     apiDefaultTxSudo,
     chainSS58,

--- a/packages/react-api/src/types.ts
+++ b/packages/react-api/src/types.ts
@@ -18,6 +18,7 @@ export interface BareProps {
 export interface ApiState {
   apiDefaultTx: SubmittableExtrinsicFunction;
   apiDefaultTxSudo: SubmittableExtrinsicFunction;
+  apiDefaultNft: string;
   chainSS58: number;
   hasInjectedAccounts: boolean;
   isApiReady: boolean;

--- a/packages/react-hooks/src/ctx/types.ts
+++ b/packages/react-hooks/src/ctx/types.ts
@@ -12,6 +12,7 @@ import type { BlockNumber, EventRecord } from '@polkadot/types/interfaces';
 export interface ApiState {
   apiDefaultTx: SubmittableExtrinsicFunction;
   apiDefaultTxSudo: SubmittableExtrinsicFunction;
+  apiDefaultNft: string;
   chainSS58: number;
   hasInjectedAccounts: boolean;
   isApiReady: boolean;


### PR DESCRIPTION
More specifically for Nodle spec version >= 23 use substrateUniques for page-nfts queries and events

This is an alternative implementation for #33. The reason I prefer and suggest this is that I believe we shouldn't mess with the way modules are places under the api. While we are moving the queries and events of the uniques pallet to the new place called substrateUniques, we still have queries and events for "uniques" which should be routed to our Nodle uniques pallet.