### PR TITLE
added new OnFinality testnet wss

### DIFF
--- a/packages/apps-config/src/endpoints/nodle.ts
+++ b/packages/apps-config/src/endpoints/nodle.ts
@@ -28,7 +28,7 @@ export function createNodle (t: TFunction, firstOnly: boolean, withSort: boolean
       info: 'nodle',
       text: t('rpc.nodle-paradis', 'Testnet', { ns: 'apps-config' }),
       providers: {
-        OnFinality: 'wss://nodle-paradis.api.onfinality.io/public-ws'
+        OnFinality: 'wss://node-6957502816543653888.lh.onfinality.io/ws?apikey=09b04494-3139-4b57-a5d1-e1c4c18748ce'
       },
       ui: {
         color: '#1ab394',


### PR DESCRIPTION
As the current testnet url will be disabled we planned to use this new one: wss://node-6957502816543653888.lh.onfinality.io/ws?apikey=09b04494-3139-4b57-a5d1-e1c4c18748ce